### PR TITLE
Fix/refresh token only on expiration

### DIFF
--- a/functions/src/modules/authenticators/infrastructure/services/google-calendar.service.ts
+++ b/functions/src/modules/authenticators/infrastructure/services/google-calendar.service.ts
@@ -45,6 +45,11 @@ export class GoogleOAuthStrategy implements OAuth2Repository {
   }
 
   async refreshToken(oldAuth: Omit<Access, "user">): Promise<Omit<Access, "user">> {
+    // TODO: do this for all platforms
+    if (await this.checkTokenValidity(oldAuth.accessToken)) {
+      console.log("STILL VALID");
+      return oldAuth;
+    }
     try {
       const { data } = await axios.post(
         "https://oauth2.googleapis.com/token",
@@ -89,5 +94,18 @@ export class GoogleOAuthStrategy implements OAuth2Repository {
       email: data.email,
       name: data.name,
     };
+  }
+
+  private async checkTokenValidity(token: string): Promise<boolean> {
+    try {
+      await axios.get("https://www.googleapis.com/oauth2/v1/userinfo?alt=json", {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      });
+      return true;
+    } catch (error) {
+      return false;
+    }
   }
 }


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description
By Google Calendar policies the refresh_token may expire due to usage. This implementation first checks if the access token is still valid before requesting a new token.

NOTE: while the OAuth application is in testing phase the refresh_token will only last for one week.

<!--- Describe your changes in detail -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
